### PR TITLE
Enable numpy-style docstring linting (ruff pydocstyle)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,9 +17,9 @@ repos:
         args: ["--fix=lf"]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.3.4
+    rev: v0.15.2
     hooks:
-      # Run the linter
+      # Run the linter (rules incl. numpy-style docstrings "D" are read from pyproject.toml)
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
       # Run the formatter

--- a/StatsTest/__init__.py
+++ b/StatsTest/__init__.py
@@ -1,4 +1,4 @@
-"""Implementing Multiple Statistical Tests in Python"""
+"""Implementing Multiple Statistical Tests in Python."""
 
 __version__ = "0.1.0"
 

--- a/StatsTest/categorical_tests.py
+++ b/StatsTest/categorical_tests.py
@@ -1,3 +1,5 @@
+"""Statistical tests for categorical data."""
+
 from collections.abc import Sequence
 
 import numpy as np
@@ -37,7 +39,7 @@ def chi_squared_test(cont_table: Sequence[Sequence[float]] | np.ndarray) -> tupl
 
 
 def g_test(cont_table: Sequence[Sequence[float]] | np.ndarray) -> tuple[float, float]:
-    """Found in scipy.stats as chi2_contingency(lambda_="log-likelihood")
+    """Found in scipy.stats as chi2_contingency(lambda_="log-likelihood").
 
     A likelihood ratio test used for determine if the difference between our observed results and expected results in
     our contingency table are likely to happen due to chance.
@@ -65,7 +67,7 @@ def g_test(cont_table: Sequence[Sequence[float]] | np.ndarray) -> tuple[float, f
 
 
 def fisher_test(cont_table: Sequence[Sequence[float]] | np.ndarray, alternative: str = "two-sided") -> float:
-    """Found in scipy.stats as fisher_exact
+    """Found in scipy.stats as fisher_exact.
 
     Used to determine the exact likelihood that we would observe a measurement in our 2x2 contingency table that
     is just as extreme, if not moreso, than our observed results.
@@ -127,7 +129,7 @@ def fisher_test(cont_table: Sequence[Sequence[float]] | np.ndarray, alternative:
 
 
 def mcnemar_test(cont_table: Sequence[Sequence[float]] | np.ndarray) -> tuple[float, float]:
-    """Found in statsmodels as mcnemar
+    """Found in statsmodels as mcnemar.
 
     Used when we have paired nominal data that is organized in a 2x2 contingency table. It is used to test the
     assumption that the marginal column and row probabilities are equal, i.e., that the probability that b and c
@@ -159,7 +161,7 @@ def mcnemar_test(cont_table: Sequence[Sequence[float]] | np.ndarray) -> tuple[fl
 
 
 def cmh_test(tables: Sequence[Sequence[float]] | np.ndarray) -> tuple[float, float]:
-    """Found in statsmodels as Stratified Table.test_null_odds()
+    """Found in statsmodels as Stratified Table.test_null_odds().
 
     Used when we want to evaluate the association between a binary predictor/treatment and a binary outcome variable
     with data that is stratified or matched. Our null hypothesis is that the common-odds ratio is 1 while our
@@ -205,7 +207,7 @@ def cmh_test(tables: Sequence[Sequence[float]] | np.ndarray) -> tuple[float, flo
 
 
 def woolf_test(tables: Sequence[Sequence[float]] | np.ndarray) -> tuple[float, float]:
-    """Not found in either scipy or statsmodels
+    """Not found in either scipy or statsmodels.
 
     Used to test the homogeneity of the odds ratio of each contingency table. Unlike Breslow-Day, compares
     the actual results to the expected Mantel-Haenzel odds ratio for each strata.
@@ -243,7 +245,7 @@ def woolf_test(tables: Sequence[Sequence[float]] | np.ndarray) -> tuple[float, f
 
 
 def breslow_day_test(tables: Sequence[Sequence[float]] | np.ndarray) -> tuple[float, float]:
-    """Found in statsmodels as StratifiedTable.test_equal_odds()
+    """Found in statsmodels as StratifiedTable.test_equal_odds().
 
     Computes the likelihood that the odds ratio for each strata is the same, by comparing the first
     row and column with its expected pooled ratio amount
@@ -302,7 +304,7 @@ def breslow_day_test(tables: Sequence[Sequence[float]] | np.ndarray) -> tuple[fl
 
 
 def bowker_test(cont_table: Sequence[Sequence[float]] | np.ndarray) -> tuple[float, float]:
-    """Found in statsmodels as TableSymmetry or as bowker_symmetry
+    """Found in statsmodels as TableSymmetry or as bowker_symmetry.
 
     Used to test if a given square table is symmetric about the main diagonal
 

--- a/StatsTest/correlation_tests.py
+++ b/StatsTest/correlation_tests.py
@@ -1,3 +1,5 @@
+"""Statistical tests for correlation between variables."""
+
 from collections.abc import Sequence
 from math import factorial, sqrt
 
@@ -8,7 +10,7 @@ from StatsTest.utils import _check_table
 
 
 def pearson_test(x: Sequence[float] | np.ndarray, y: Sequence[float] | np.ndarray) -> tuple[float, float]:
-    """Found in scipy.stats as pearsonr
+    """Found in scipy.stats as pearsonr.
 
     Used to evaluate the pearson correlation between X and Y.
 
@@ -39,7 +41,7 @@ def pearson_test(x: Sequence[float] | np.ndarray, y: Sequence[float] | np.ndarra
 
 
 def spearman_test(x: Sequence[float] | np.ndarray, y: Sequence[float] | np.ndarray) -> tuple[float, float]:
-    """Found in scipy.stats as spearmanr
+    """Found in scipy.stats as spearmanr.
 
     Used to evaluate the correlation between the ranks of "X" and "Y", that is, if there exists a
     monotonic relationship between X and Y.
@@ -76,7 +78,7 @@ def kendall_tau_test(
     y: Sequence[float] | np.ndarray,
     method: str = "hypothesis",
 ) -> tuple[float, float]:
-    """Found in scipy.stats as kendalltau
+    """Found in scipy.stats as kendalltau.
 
     Used to evaluate if two ordinal variables are correlated to one another.
 
@@ -160,7 +162,7 @@ def kendall_tau_test(
 def point_biserial_correlation_test(
     x: Sequence[float] | np.ndarray, y: Sequence[float] | np.ndarray
 ) -> tuple[float, float]:
-    """Found in scipy.stats as pointbiserialr
+    """Found in scipy.stats as pointbiserialr.
 
     Parameters
     ----------
@@ -195,7 +197,7 @@ def point_biserial_correlation_test(
 def rank_biserial_correlation_test(
     x: Sequence[float] | np.ndarray, y: Sequence[float] | np.ndarray
 ) -> tuple[float, float]:
-    """Not found in scipy.stats or statsmodels
+    """Not found in scipy.stats or statsmodels.
 
     Parameters
     ----------

--- a/StatsTest/gof_tests.py
+++ b/StatsTest/gof_tests.py
@@ -1,3 +1,5 @@
+"""Goodness-of-fit statistical tests."""
+
 from collections.abc import Sequence
 from math import asinh, log, sqrt
 
@@ -11,7 +13,7 @@ def chi_goodness_of_fit_test(
     observed: Sequence[float] | np.ndarray,
     expected: Sequence[float] | np.ndarray | None = None,
 ) -> tuple[float, float]:
-    """Found in scipy.stats as chisquare
+    """Found in scipy.stats as chisquare.
 
     Used when we cannot divide the data cleanly into a contingency table or when we have actual expected results to
     compare to.
@@ -42,7 +44,7 @@ def g_goodness_of_fit_test(
     observed: Sequence[float] | np.ndarray,
     expected: Sequence[float] | np.ndarray | None = None,
 ) -> tuple[float, float]:
-    """Found in scipy.stats as power_divergence(lambda_="log-likelihood")
+    """Found in scipy.stats as power_divergence(lambda_="log-likelihood").
 
     Similar to chi_goodness_of_fit_test, used when we cannot divide the data cleanly into a contingency table or when we
     have actual expected results to compare to.
@@ -70,7 +72,7 @@ def g_goodness_of_fit_test(
 
 
 def jarque_bera_test(data: Sequence[float] | np.ndarray) -> tuple[float, float]:
-    """Found in statsmodels as jarque_bera
+    """Found in statsmodels as jarque_bera.
 
     This test is used to evaluate whether the skew and kurtosis of said data follows that of a normal distribution
 
@@ -100,7 +102,7 @@ def ljung_box_test(
     data: Sequence[float] | np.ndarray,
     num_lags: int | Sequence[float] | np.ndarray | None = None,
 ) -> tuple[float, float]:
-    """Found in statsmodels as acorr_ljung(boxpierce=False)
+    """Found in statsmodels as acorr_ljung(boxpierce=False).
 
     Used to determine if any group of autocorrelations in a time series dataset are different from zero
 
@@ -142,7 +144,7 @@ def box_pierce_test(
     data: Sequence[float] | np.ndarray,
     num_lags: int | Sequence[float] | np.ndarray | None = None,
 ) -> tuple[float, float]:
-    """Found in statsmodels as acorr_ljung(boxpierce=True)
+    """Found in statsmodels as acorr_ljung(boxpierce=True).
 
     Used to determine if any group of autocorrelations in a time series dataset are different from zero
 
@@ -247,7 +249,7 @@ def kurtosis_test(data: Sequence[float] | np.ndarray) -> tuple[float, float]:
 
 
 def k_squared_test(data: Sequence[float] | np.ndarray) -> tuple[float, float]:
-    """Found in scipy.stats as normaltest
+    """Found in scipy.stats as normaltest.
 
     Used to determine the likelihood that our sample dataset comes from a normal distribution based on its
     skewness and kurtosis.

--- a/StatsTest/multi_group_tests.py
+++ b/StatsTest/multi_group_tests.py
@@ -1,3 +1,5 @@
+"""Statistical tests for comparing multiple groups."""
+
 from collections.abc import Sequence
 from math import sqrt
 
@@ -8,7 +10,7 @@ from StatsTest.utils import _check_table
 
 
 def levene_test(*args: Sequence[float] | np.ndarray) -> tuple[float, float]:
-    """Found in scipy.stats as levene(center='mean')
+    """Found in scipy.stats as levene(center='mean').
 
     Used to determine if a variable/observation in multiple groups has equal variances across all groups. In short, does
     each group have equal variance?
@@ -47,7 +49,7 @@ def levene_test(*args: Sequence[float] | np.ndarray) -> tuple[float, float]:
 
 
 def brown_forsythe_test(*args: Sequence[float] | np.ndarray) -> tuple[float, float]:
-    """Found in scipy.stats as levene(center='median')
+    """Found in scipy.stats as levene(center='median').
 
     Used instead of general levene test if we believe our data to be non-normal.
 
@@ -85,7 +87,7 @@ def brown_forsythe_test(*args: Sequence[float] | np.ndarray) -> tuple[float, flo
 
 
 def one_way_f_test(*args: Sequence[float] | np.ndarray) -> tuple[float, float]:
-    """Found in scipy.stats as f_oneway
+    """Found in scipy.stats as f_oneway.
 
     Used to measure if multiple normal populations have the same mean. Note that this test is very sensitive to
     non-normal data, meaning that it should not be used unless we can verify that the data is normally distributed.
@@ -123,7 +125,7 @@ def one_way_f_test(*args: Sequence[float] | np.ndarray) -> tuple[float, float]:
 
 
 def bartlett_test(*args: Sequence[float] | np.ndarray) -> tuple[float, float]:
-    """Found in scipy.stats as bartlett
+    """Found in scipy.stats as bartlett.
 
     This test is used to determine if multiple samples are from a population of equal variances. Note that this test
     is much more sensitive to data that is non-normal compared to Levene or Brown-Forsythe.
@@ -159,7 +161,7 @@ def bartlett_test(*args: Sequence[float] | np.ndarray) -> tuple[float, float]:
 
 
 def cochran_q_test(*args: Sequence[float] | np.ndarray) -> tuple[float, float]:
-    """Found in statsmodels as chochrans_q
+    """Found in statsmodels as chochrans_q.
 
     Used to determine if k treatments in a 2 way randomized block design have identical effects. Note that this test
     requires that there be only two variables encoded: 1 for success and 0 for failure.
@@ -193,9 +195,9 @@ def cochran_q_test(*args: Sequence[float] | np.ndarray) -> tuple[float, float]:
 
 
 def jonckheere_trend_test(*args: Sequence[float] | np.ndarray, **kwargs: str) -> tuple[float, float]:
-    """This test is not found in scipy or statsmodels
+    """Test whether the population medians of each group follow an a priori ordering.
 
-    This test is used to determine if the population medians for each group have an a priori ordering.
+    This test is not found in scipy or statsmodels.
     Note that the default alternative hypothesis is that median_1 <= median_2 <= median_3 <= ... <= median_k, with at
     least one strict inequality.
 
@@ -258,7 +260,7 @@ def jonckheere_trend_test(*args: Sequence[float] | np.ndarray, **kwargs: str) ->
 
 
 def mood_median_test(*args: Sequence[float] | np.ndarray, **kwargs: str) -> tuple[float, float]:
-    """Found in scipy.stats as median_test
+    """Found in scipy.stats as median_test.
 
     This test is used to determine if two or more samples/observations come from a population with the same median.
 

--- a/StatsTest/outliers_test.py
+++ b/StatsTest/outliers_test.py
@@ -1,3 +1,5 @@
+"""Statistical tests for detecting outliers."""
+
 from collections.abc import Sequence
 from math import sqrt
 
@@ -9,7 +11,7 @@ from StatsTest.utils import _check_table
 
 
 def tukey_fence_test(data: Sequence[float] | np.ndarray, coef: float = 1.5) -> np.ndarray:
-    """Not found in either scipy.stats or statsmodels
+    """Not found in either scipy.stats or statsmodels.
 
     Used to determine outliers in a normally distributed dataset.
 
@@ -37,7 +39,7 @@ def grubbs_test(
     alternative: str = "two-sided",
     alpha: float = 0.05,
 ) -> float | int | None:
-    """Not found in either scipy.stats or statsmodels
+    """Not found in either scipy.stats or statsmodels.
 
     Used to determine if there exists one outlier in the dataset based on their dispersion from the mean.
     Note that this assumes that the data is normally distributed.
@@ -88,7 +90,7 @@ def grubbs_test(
 def extreme_studentized_deviate_test(
     data: Sequence[float] | np.ndarray, num_outliers: int = 1, alpha: float = 0.05
 ) -> tuple[int, list[float]]:
-    """Not found in either scipy.stats or statsmodels
+    """Not found in either scipy.stats or statsmodels.
 
     Used when we think there are at most k outliers, as other tests such as Grubbs or Tietjen-Moore rely on there existing
     exactly k number of outliers. Note that this assumes the data is normally distributed.
@@ -142,7 +144,7 @@ def tietjen_moore_test(
     alternative: str = "two-sided",
     alpha: float = 0.05,
 ) -> list[float] | None:
-    """Not found in either scipy.stats or statsmodels
+    """Not found in either scipy.stats or statsmodels.
 
     An extension of Grubbs where it is used to determine if there exists exactly k outliers in the dataset based on their
     dispersion from the mean. Note that this assumes that the data is normally distributed.
@@ -246,7 +248,7 @@ def peirce_test(
     num_outliers: int = 1,
     num_coef: int = 1,
 ) -> np.ndarray:
-    """Not found in either scipy.stats or statsmodels
+    """Not found in either scipy.stats or statsmodels.
 
     Parameters
     ----------
@@ -298,7 +300,7 @@ def peirce_test(
 
 
 def dixon_q_test(data: Sequence[float] | np.ndarray, alpha: float = 0.01) -> np.ndarray:
-    """Not found in either scipy.stats or statsmodels
+    """Not found in either scipy.stats or statsmodels.
 
     Parameters
     ----------
@@ -424,7 +426,7 @@ def dixon_q_test(data: Sequence[float] | np.ndarray, alpha: float = 0.01) -> np.
 
 
 def thompson_tau_test(data: Sequence[float] | np.ndarray, alpha: float = 0.05) -> list[float]:
-    """Not found in either scipy.stats or statsmodels
+    """Not found in either scipy.stats or statsmodels.
 
     Uses the Thompson-Tau criteria to iteratively identify outliers until no more exist.
 
@@ -459,7 +461,7 @@ def thompson_tau_test(data: Sequence[float] | np.ndarray, alpha: float = 0.05) -
 
 
 def mad_median_test(data: Sequence[float] | np.ndarray, alpha: float = 0.05) -> list[float]:
-    """Not found in either scipy.stats or statsmodels
+    """Not found in either scipy.stats or statsmodels.
 
     Uses the median absolute deviation rule as a method of outlier detection.
 

--- a/StatsTest/post_hoc_tests.py
+++ b/StatsTest/post_hoc_tests.py
@@ -1,3 +1,5 @@
+"""Post-hoc statistical tests."""
+
 from collections.abc import Sequence
 from itertools import chain
 from math import sqrt
@@ -12,7 +14,7 @@ from StatsTest.utils import _sse
 def dunnett_test(
     control: Sequence[float] | np.ndarray, alpha: float = 0.05, *args: Sequence[float] | np.ndarray
 ) -> np.ndarray:
-    """Not found in either scipy or statsmodels
+    """Not found in either scipy or statsmodels.
 
     This test is used to compare the means of several groups to a control and determine which groups are significant
 
@@ -1773,7 +1775,7 @@ def dunnett_test(
 
 
 def duncan_multiple_range_test(alpha: float = 0.05, *args: Sequence[float] | np.ndarray) -> list[tuple[float, ...]]:
-    """Not found in either scipy or statsmodels
+    """Not found in either scipy or statsmodels.
 
     This test is used to compare the means of several groups and determine which groups are significant
 
@@ -3059,7 +3061,7 @@ def duncan_multiple_range_test(alpha: float = 0.05, *args: Sequence[float] | np.
 
 
 def tukey_range_test(*args: Sequence[float] | np.ndarray) -> list[list[object]]:
-    """Found in statsmodels as pairwise_tukeyhsd
+    """Found in statsmodels as pairwise_tukeyhsd.
 
     This test compares all possible pairs of means and determines if there are any differences in these pairs.
 
@@ -3101,7 +3103,7 @@ def tukey_range_test(*args: Sequence[float] | np.ndarray) -> list[list[object]]:
 
 
 def scheffe_test(*args: Sequence[float] | np.ndarray) -> list[list[object]]:
-    """Not found in scipy or statsmodels
+    """Not found in scipy or statsmodels.
 
     This test compares all possible means and determines which groups are significantly different.
 

--- a/StatsTest/proportion_tests.py
+++ b/StatsTest/proportion_tests.py
@@ -1,3 +1,5 @@
+"""Statistical tests for proportions."""
+
 from collections.abc import Sequence
 from math import sqrt
 
@@ -12,7 +14,7 @@ def one_sample_proportion_z_test(
     pop_mean: float,
     alternative: str = "two-sided",
 ) -> tuple[float, float]:
-    """Found in statsmodels as proportions_ztest
+    """Found in statsmodels as proportions_ztest.
 
     Used when comparing whether our observed proportion mean is different from the population mean, assuming that the
     proportion mean is normally distributed.
@@ -66,7 +68,7 @@ def two_sample_proportion_z_test(
     data_2: Sequence[float] | np.ndarray,
     alternative: str = "two-sided",
 ) -> tuple[float, float]:
-    """Found in statsmodels as proportions_ztest
+    """Found in statsmodels as proportions_ztest.
 
     Used when we are comparing whether or not two proportion means are the same, given that both of them come from a
     normal distribution.
@@ -119,7 +121,7 @@ def binomial_test(
     alternative: str = "two-sided",
     success_prob: float | None = None,
 ) -> float:
-    """The binomial test can be found in scipy.stats as binom_test.
+    """Perform a binomial test (scipy.stats.binom_test).
 
     Used to determine if the likelihood that our observed measurements could occur given that we know the prior probability.
     For example, if we rolled a die 100 times and a 6 appeared 40 times, our test would measure the likelihood this
@@ -185,7 +187,7 @@ def chi_square_proportion_test(
     n_total: Sequence[float] | np.ndarray,
     expected: Sequence[float] | np.ndarray | None = None,
 ) -> tuple[float, float]:
-    """Not found in either statsmodels or scipy.stats
+    """Not found in either statsmodels or scipy.stats.
 
     Used when we are given proportions of success (as well as total participants) instead of
     numbers of success.
@@ -245,7 +247,7 @@ def g_proportion_test(
     n_total: Sequence[float] | np.ndarray,
     expected: Sequence[float] | np.ndarray | None = None,
 ) -> tuple[float, float]:
-    """Not found in either statsmodels or scipy.stats
+    """Not found in either statsmodels or scipy.stats.
 
     Used when we are given proportions of success (as well as total participants) instead of
     numbers of success

--- a/StatsTest/rank_tests.py
+++ b/StatsTest/rank_tests.py
@@ -1,3 +1,5 @@
+"""Rank-based (non-parametric) statistical tests."""
+
 from collections.abc import Sequence
 from math import sqrt
 
@@ -12,7 +14,8 @@ def two_sample_mann_whitney_test(
     data_2: Sequence[float] | np.ndarray,
     alternative: str = "two-sided",
 ) -> tuple[float, float]:
-    """This test can be found in scipy.stats as mannwhitneyu
+    """Perform the Mann-Whitney U test (scipy.stats.mannwhitneyu).
+
     Used when we want to test whether or not the distribution of two ordinal response variables are equal or not,
     assuming that each sample is independent of one another.
 
@@ -68,7 +71,7 @@ def two_sample_wilcoxon_test(
     alternative: str = "two-sided",
     handle_zero: str = "wilcox",
 ) -> tuple[float, float]:
-    """This test can be found in scipy.stats as wilcoxon
+    """Perform the Wilcoxon signed-rank test (scipy.stats.wilcoxon).
 
     Used when we want to compare two related or paired samples, or repeated measurements, and see if their population
     mean ranks differ. Also used when we cannot assume that the samples are normally distributed.
@@ -122,7 +125,7 @@ def two_sample_wilcoxon_test(
 
 
 def friedman_test(*args: Sequence[float] | np.ndarray) -> tuple[float, float]:
-    """This can be found in scipy.stats as friedmanchisquare
+    """Perform the Friedman test (scipy.stats.friedmanchisquare).
 
     Used to detect the differences in treatments across multiple test attempts. For example:
     Suppose there are n wine judges each rate k different wines. Are any of the k wines ranked consistently higher or
@@ -156,7 +159,7 @@ def friedman_test(*args: Sequence[float] | np.ndarray) -> tuple[float, float]:
 
 
 def quade_test(*args: Sequence[float] | np.ndarray) -> tuple[float, float]:
-    """Not found in either scipy or statsmodels
+    """Not found in either scipy or statsmodels.
 
     Used to determine if there is at least one treatment different than the others. Note that it does not tell us which
     treatment is different or how many differences there are.
@@ -191,7 +194,7 @@ def quade_test(*args: Sequence[float] | np.ndarray) -> tuple[float, float]:
 
 
 def page_trend_test(*args: Sequence[float] | np.ndarray, **kwargs: str) -> tuple[float, float]:
-    """Not found in either scipy or statsmodels
+    """Not found in either scipy or statsmodels.
 
     Used to evaluate whether or not there is a monotonic trend within each treatment/condition. Note that the default
     alternative hypothesis is that treatment_1 >= treatment_2 >= treatment_3 >= .... >= treatment_n, with at least
@@ -244,7 +247,7 @@ def page_trend_test(*args: Sequence[float] | np.ndarray, **kwargs: str) -> tuple
 
 
 def kruskal_wallis_test(*args: Sequence[float] | np.ndarray) -> tuple[float, float]:
-    """Found in scipy.stats as kruskal
+    """Found in scipy.stats as kruskal.
 
     This test is used to determine whether or not two or more samples originate from the same distribution.
     Note that this requires the samples to be independent of one another, and that it only tells us if there is a
@@ -281,7 +284,7 @@ def kruskal_wallis_test(*args: Sequence[float] | np.ndarray) -> tuple[float, flo
 
 
 def fligner_kileen_test(*args: Sequence[float] | np.ndarray, **kwargs: str) -> tuple[float, float]:
-    """Found in scipy.stats as fligner
+    """Found in scipy.stats as fligner.
 
     Used to test the homogeneity of group variances, making no assumptions of the data distribution beforehand
 
@@ -447,7 +450,7 @@ def mood_test(
     data_2: Sequence[float] | np.ndarray,
     alternative: str = "two-sided",
 ) -> tuple[float, float]:
-    """Found in scipy.stats as mood
+    """Found in scipy.stats as mood.
 
     Used to measure the level of dispersion (difference from median) of the ranks of the two datasets.
 
@@ -496,7 +499,7 @@ def cucconi_test(
     data_2: Sequence[float] | np.ndarray,
     how: str = "bootstrap",
 ) -> tuple[float, float]:
-    """Not found in scipy.stats or statsmodels
+    """Not found in scipy.stats or statsmodels.
 
     Used to compare the central tendency and variability in two samples.
 

--- a/StatsTest/sample_tests.py
+++ b/StatsTest/sample_tests.py
@@ -1,3 +1,5 @@
+"""One- and two-sample statistical tests."""
+
 import warnings
 from collections.abc import Sequence
 from math import factorial, sqrt
@@ -21,7 +23,7 @@ def one_sample_z_test(
     pop_mean: float,
     alternative: str = "two-sided",
 ) -> tuple[float, float]:
-    """This test can be found in statsmodels as ztest
+    """Perform a one-sample Z-test (statsmodels.ztest).
 
     Determines the likelihood that our sample mean differs from our population mean, assuming that the data follows a
     normal distribution.
@@ -69,7 +71,7 @@ def two_sample_z_test(
     data_2: Sequence[float] | np.ndarray,
     alternative: str = "two-sided",
 ) -> tuple[float, float]:
-    """This test can be found in statsmodels as ztest_ind
+    """Perform a two-sample Z-test (statsmodels.ztest_ind).
 
     Determines the likelihood that the distribution of two data points is significantly different, assuming that both
     data points are derived from a normal distribution.
@@ -116,7 +118,7 @@ def one_sample_t_test(
     pop_mean: float,
     alternative: str = "two-sided",
 ) -> tuple[float, float]:
-    """This test can be found in scipy.stats as ttest_1samp
+    """Perform a one-sample t-test (scipy.stats.ttest_1samp).
 
     Used when we want to compare our sample mean to that of an expected population mean, and while we assume that the
     data follows a normal distribution, our sample size is too small to reliably use the z-test.
@@ -165,7 +167,7 @@ def two_sample_t_test(
     alternative: str = "two-sided",
     paired: bool = False,
 ) -> tuple[float, float]:
-    """This test can be found in scipy.stats as either ttest_rel or ttest_ind
+    """Perform a two-sample t-test (scipy.stats.ttest_rel or ttest_ind).
 
     Used when we want to compare the distributions of two samples, and while we assume that they both follow a normal
     distribution, their sample size is too small to reliably use a z-test.
@@ -233,6 +235,7 @@ def trimmed_means_test(
     alternative: str = "two-sided",
 ) -> tuple[float, float]:
     """Not found in scipy.stats or statsmodels.
+
     Used when we wish to perform a two-sample t-test, but suspect that the data is being heavily influenced by outliers,
     i.e., cannot assume normality.
 
@@ -399,7 +402,7 @@ def binomial_sign_test(
     alternative: str = "two-sided",
     success_prob: float = 0.5,
 ) -> float:
-    """Found in scipy as sign_test
+    """Found in scipy as sign_test.
 
     Used to determine whether or not the measured differences between two groups (X and Y) is
     significantly greater and/or less than each other. For instance, we might use this to determine if the weight loss
@@ -450,7 +453,7 @@ def wald_wolfowitz_test(
     expected: Sequence[float] | np.ndarray | None = None,
     cutoff: str = "median",
 ) -> tuple[float, float]:
-    """Found in statsmodels as runstest_1samp
+    """Found in statsmodels as runstest_1samp.
 
     Used to determine if the elements of a dataset/sequence are mutually independent
 
@@ -503,7 +506,7 @@ def trinomial_test(
     data_2: Sequence[float] | np.ndarray,
     alternative: str = "two-sided",
 ) -> tuple[float, float]:
-    """Not found in scipy.stats or statsmodels
+    """Not found in scipy.stats or statsmodels.
 
     Used on paired-data when the sign test loses power, that is, when there exists instances of "zero observations" or
     differences of zero between the paired-data.

--- a/StatsTest/utils.py
+++ b/StatsTest/utils.py
@@ -1,3 +1,5 @@
+"""Internal helper functions for statistical computations."""
+
 from collections.abc import Sequence
 from math import factorial, sqrt
 from numbers import Number
@@ -8,7 +10,7 @@ from scipy.stats import binom
 
 
 def _standard_error(std: float, n: int) -> float:
-    """Calculates the standard error given the standard deviation and length of data
+    """Calculate the standard error given the standard deviation and length of data.
 
     Parameters
     ----------
@@ -31,7 +33,7 @@ def _standard_error(std: float, n: int) -> float:
 
 
 def _hypergeom_distribution(a: int | float, b: int | float, c: int | float, d: int | float) -> float:
-    """Calculates the hyper-geometric distribution for a given a, b, c and d
+    """Calculate the hyper-geometric distribution for a given a, b, c and d.
 
     Parameters
     ----------
@@ -66,7 +68,7 @@ def _check_table(
     table: Sequence[float] | Sequence[Sequence[float]] | np.ndarray | pd.Series | pd.DataFrame,
     only_count: bool = False,
 ) -> np.ndarray:
-    """Performs checks on our table to ensure that it is suitable for our statistical tests
+    """Perform checks on our table to ensure that it is suitable for our statistical tests.
 
     Parameters
     ----------
@@ -109,7 +111,7 @@ def _sse(
     square_data: Sequence[float] | np.ndarray,
     n_data: Sequence[float] | np.ndarray,
 ) -> float:
-    """Calculates the sum of squares for the errors
+    """Calculate the sum of squares for the errors.
 
     Parameters
     ----------
@@ -142,8 +144,9 @@ def _sse(
 
 
 def _right_extreme(n_instances: int, n_total: int, prob: float) -> float:
-    """Used for a binomial problem. Calculates the exact likelihood of finding observations as and more extreme
-    than our observed value
+    """Calculate the exact likelihood of finding observations as and more extreme than our observed value.
+
+    Used for a binomial problem.
 
     Parameters
     ----------
@@ -166,8 +169,9 @@ def _right_extreme(n_instances: int, n_total: int, prob: float) -> float:
 
 
 def _left_extreme(n_instances: int, n_total: int, prob: float) -> float:
-    """Used for a binomial problem. Calculates the exact likelihood of finding observations as and less extreme
-    than our observed value
+    """Calculate the exact likelihood of finding observations as and less extreme than our observed value.
+
+    Used for a binomial problem.
 
     Parameters
     ----------
@@ -190,7 +194,7 @@ def _left_extreme(n_instances: int, n_total: int, prob: float) -> float:
 
 
 def _skew(data: Sequence[float] | np.ndarray) -> float:
-    """Calculates the skew (third moment) of the data
+    """Calculate the skew (third moment) of the data.
 
     Parameters
     ----------
@@ -212,7 +216,7 @@ def _skew(data: Sequence[float] | np.ndarray) -> float:
 
 
 def _kurtosis(data: Sequence[float] | np.ndarray) -> float:
-    """Calculates the kurtosis (fourth moment) of the data
+    """Calculate the kurtosis (fourth moment) of the data.
 
     Parameters
     ----------
@@ -234,7 +238,7 @@ def _kurtosis(data: Sequence[float] | np.ndarray) -> float:
 
 
 def _autocorr(data: Sequence[float] | np.ndarray, lags: Sequence[float] | np.ndarray) -> np.ndarray:
-    """Calculates the autocorrelation for a given time series dataset given a set amount of lags
+    """Calculate the autocorrelation for a given time series dataset given a set amount of lags.
 
     Parameters
     ----------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,6 +124,7 @@ select = [
     "UP",  # pyupgrade
     "ARG", # flake8-unused-arguments
     "SIM", # flake8-simplify
+    "D",   # pydocstyle (numpy-style docstrings)
 ]
 ignore = [
     "E501",  # line too long (handled by formatter)
@@ -133,8 +134,12 @@ ignore = [
 fixable = ["ALL"]
 unfixable = []
 
+[tool.ruff.lint.pydocstyle]
+convention = "numpy"
+
 [tool.ruff.lint.per-file-ignores]
-"test_*.py" = ["ARG", "S101"]  # Allow assert and unused arguments in tests
+"test_*.py" = ["ARG", "S101", "D"]  # Allow assert/unused args and skip docstrings in tests
+"test/**" = ["ARG", "S101", "D"]    # Skip docstring rules across the whole test directory
 
 [tool.zuban]
 python_version = "3.13"


### PR DESCRIPTION
## Summary

Turns on numpy-style docstring linting via ruff's `pydocstyle` (`D`) rules and fixes all resulting violations. The codebase already used numpy-style docstrings — ruff just wasn't checking them.

## Changes

**Config (`pyproject.toml`)**
- Added `"D"` to `[tool.ruff.lint] select` with `[tool.ruff.lint.pydocstyle] convention = "numpy"`
- Exempted tests from docstring rules via per-file-ignores (`test_*.py` and `test/**`)

**Docstring fixes (10 source files)**
- **D100** — added module-level docstrings to all 10 modules
- **D400** — added missing trailing periods on summary lines (auto-fixed)
- **D401** — converted summaries to imperative mood (`Calculates` → `Calculate`, etc.)
- **D404** — reworded `"This test can be found in scipy.stats as X"` summaries into imperative one-liners (e.g. `Perform the Mann-Whitney U test (scipy.stats.mannwhitneyu).`)
- **D205** — added required blank line between summary and description

**Pre-commit (`.pre-commit-config.yaml`)**
- Bumped `ruff-pre-commit` `v0.3.4` → `v0.15.2` to match the local ruff version

## Verification

- `ruff check StatsTest` (full config) → all checks passed
- `ruff format --check` → all files formatted
- `pre-commit run ruff` and `ruff-format` on all files → passed

Docstrings/config only — no runtime behavior changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)