### PR TITLE
Run tests on Ubuntu, macOS, and Windows for Python 3.13/3.14

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -40,12 +40,12 @@ jobs:
         continue-on-error: true
 
   test:
-    name: Test on Python ${{ matrix.python-version }}
+    name: Test on ${{ matrix.os }} / Python ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.13", "3.14"]
 
     steps:
@@ -68,7 +68,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
-        if: matrix.python-version == '3.13'
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13'
         with:
           file: ./coverage.xml
           fail_ci_if_error: false


### PR DESCRIPTION
## Summary
- Expand the CI `test` job matrix `os` to `[ubuntu-latest, macos-latest, windows-latest]`, keeping Python `3.13` and `3.14` — **6 test combinations** total.
- Update the job name to `Test on ${{ matrix.os }} / Python ${{ matrix.python-version }}` so each combination is clearly labeled in the Actions UI.
- Scope the Codecov upload to `ubuntu-latest` + `3.13` only, so coverage isn't uploaded three times (once per OS).

`fail-fast: false` was already set, so one failing combination won't cancel the others.

🤖 Generated with [Claude Code](https://claude.com/claude-code)