### PR TITLE
Derive CI Python matrix from pyproject.toml classifiers

### DIFF
--- a/.github/scripts/supported_pythons.py
+++ b/.github/scripts/supported_pythons.py
@@ -1,0 +1,35 @@
+"""Derive the supported Python versions from pyproject.toml classifiers.
+
+Emits GitHub Actions step outputs so CI never hardcodes a version list:
+
+    versions=["3.13", "3.14"]   # JSON array, consumed via fromJson() in a matrix
+    latest=3.14                 # newest supported version, used for single-version jobs
+
+Run as: python .github/scripts/supported_pythons.py >> "$GITHUB_OUTPUT"
+"""
+
+import json
+import tomllib
+
+PREFIX = "Programming Language :: Python :: "
+
+
+def main() -> None:
+    with open("pyproject.toml", "rb") as f:
+        classifiers = tomllib.load(f)["project"]["classifiers"]
+
+    # Keep only "3.13"-style classifiers; drop the bare "3" major-only entry.
+    versions = sorted(
+        (c.removeprefix(PREFIX) for c in classifiers if c.startswith(PREFIX) and "." in c.removeprefix(PREFIX)),
+        key=lambda v: tuple(map(int, v.split("."))),
+    )
+
+    if not versions:
+        raise SystemExit("No 'Programming Language :: Python :: X.Y' classifiers found in pyproject.toml")
+
+    print(f"versions={json.dumps(versions)}")
+    print(f"latest={versions[-1]}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/supported_pythons.py
+++ b/.github/scripts/supported_pythons.py
@@ -15,6 +15,7 @@ PREFIX = "Programming Language :: Python :: "
 
 
 def main() -> None:
+    """Emit versions/latest step outputs derived from pyproject.toml classifiers."""
     with open("pyproject.toml", "rb") as f:
         classifiers = tomllib.load(f)["project"]["classifiers"]
 

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -11,9 +11,12 @@ on:
       - master
 
 jobs:
-  lint:
-    name: Lint and Format Check
+  setup:
+    name: Resolve supported Python versions
     runs-on: ubuntu-latest
+    outputs:
+      versions: ${{ steps.get.outputs.versions }}
+      latest: ${{ steps.get.outputs.latest }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -21,7 +24,24 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.x"
+
+      - name: Derive versions from pyproject.toml classifiers
+        id: get
+        run: python .github/scripts/supported_pythons.py >> "$GITHUB_OUTPUT"
+
+  lint:
+    name: Lint and Format Check
+    runs-on: ubuntu-latest
+    needs: setup
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ needs.setup.outputs.latest }}
           cache: "pip"
 
       - name: Install dependencies
@@ -42,11 +62,12 @@ jobs:
   test:
     name: Test on ${{ matrix.os }} / Python ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
+    needs: setup
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.13", "3.14"]
+        python-version: ${{ fromJson(needs.setup.outputs.versions) }}
 
     steps:
       - name: Checkout code
@@ -68,9 +89,34 @@ jobs:
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13'
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == needs.setup.outputs.latest
         with:
           file: ./coverage.xml
           fail_ci_if_error: false
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+  canary:
+    name: Canary (latest Python, incl. prereleases)
+    runs-on: ubuntu-latest
+    # Informational only: surfaces breakage on not-yet-supported Python
+    # (e.g. 3.15 betas/RCs) without ever blocking a merge.
+    continue-on-error: true
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up latest Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+          allow-prereleases: true
+          cache: "pip"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Run tests
+        run: pytest --cov=StatsTest --cov-report=term-missing

--- a/.gitignore
+++ b/.gitignore
@@ -230,6 +230,9 @@ rsconnect/
 pyvenv.cfg
 pip-selfcheck.json
 
+# The venv [Ss]cripts rule above also matches our CI helper dir; keep it tracked.
+!.github/scripts/
+
 ### VisualStudioCode ###
 .vscode/*
 !.vscode/settings.json


### PR DESCRIPTION
## What

Makes the CI Python version list **self-updating** so bumping to a new release (e.g. 3.15) is a one-line change instead of edits in four places.

### Layer 1 — dynamic matrix from a single source of truth
- New `.github/scripts/supported_pythons.py` parses the `Programming Language :: Python :: X.Y` classifiers from `pyproject.toml` and emits GitHub Actions outputs:
  ```
  versions=["3.13", "3.14"]
  latest=3.14
  ```
- New `setup` job runs the parser and exposes `versions` + `latest`.
- `test` matrix now uses `${{ fromJson(needs.setup.outputs.versions) }}` — no hardcoded list.
- `lint` pins to `needs.setup.outputs.latest` instead of a literal `"3.13"`.
- Codecov upload condition keys off `needs.setup.outputs.latest` rather than `'3.13'`.

### Canary
- New `canary` job installs the latest Python with `allow-prereleases: true` and runs the suite as `continue-on-error: true`. It flags breakage on not-yet-supported versions (e.g. 3.15 betas/RCs) without blocking merges.

### .gitignore
- The venv `[Ss]cripts` rule also matched `.github/scripts`; added a scoped `!.github/scripts/` negation so the CI helper is tracked.

## Updating for Python 3.15
Add one classifier line to `pyproject.toml` and the test matrix, lint job, and codecov target all follow. The semantic settings (`requires-python`, `ruff target-version`, `zuban python_version`) remain explicit by design.

## Testing
- Parser verified locally → `versions=["3.13", "3.14"]`, `latest=3.14`.
- Workflow YAML validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)